### PR TITLE
Discontinue modifyResponse in favour of onResponse (the library default function)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,14 @@ server.route({
 });
 ```
 ### Custom `uri` template values
-    
+
 When using the `uri` option, there are optional **default** template values that can be injected from the incoming `request`:
 
 * `{protocol}`
 * `{host}`
 * `{port}`
 * `{path}`
-    
+
 ```javascript
 server.route({
     method: 'GET',
@@ -161,7 +161,7 @@ server.route({
 ```
 **Note** The default variables of `{protocol}`, `{host}`, `{port}`, `{path}` take precedence - it's best to treat those as reserved when naming your own `request.params`.
 
-    
+
 ### Using the `mapUri` and `onResponse` options
 
 Setting both options with custom functions will allow you to map the original request to an upstream service and to processing the response from the upstream service, before sending it to the client. Cannot be used together with `host`, `port`, `protocol`, or `uri`.
@@ -177,7 +177,7 @@ server.route({
                 console.log('doing some aditional stuff before redirecting');
                 callback(null, 'https://some.upstream.service.com/');
             },
-            onResponse: function (err, res, request, reply, settings, ttl) {
+            onResponse: function (err, res, request, reply, settings, ttl, data) {
 
                 console.log('receiving the response from the upstream.');
                 Wreck.read(res, { json: true }, function (err, payload) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,7 @@ internals.schema = Joi.object({
     maxSockets: Joi.number().positive().allow(false),
 
     // added for kibi
-    modifyPayload: Joi.any()
+    onBeforeSendRequest: Joi.any()
 })
 .xor('host', 'mapUri', 'uri')
 .without('mapUri', 'port', 'protocol')
@@ -79,7 +79,7 @@ internals.handler = function (route, handlerOptions) {
     settings.mapUri = handlerOptions.mapUri || internals.mapUri(handlerOptions.protocol, handlerOptions.host, handlerOptions.port, handlerOptions.uri);
 
     // kibi: added
-    const modifyPayload = handlerOptions.modifyPayload || false;
+    const onBeforeSendRequest = handlerOptions.onBeforeSendRequest || false;
 
     if (settings.ttl === 'upstream') {
         settings._upstreamTtl = true;
@@ -189,8 +189,8 @@ internals.handler = function (route, handlerOptions) {
             };
 
             // Send request
-            if (modifyPayload) {
-                modifyPayload(request).then((payloadAndData) => {
+            if (onBeforeSendRequest) {
+                onBeforeSendRequest(request).then((payloadAndData) => {
 
                     options.payload = payloadAndData.payload;
                     _sendRequest(payloadAndData.data);

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,8 +47,7 @@ internals.schema = Joi.object({
     maxSockets: Joi.number().positive().allow(false),
 
     // added for kibi
-    modifyPayload: Joi.any(),
-    modifyResponse: Joi.any()
+    modifyPayload: Joi.any()
 })
 .xor('host', 'mapUri', 'uri')
 .without('mapUri', 'port', 'protocol')
@@ -79,8 +78,8 @@ internals.handler = function (route, handlerOptions) {
     const settings = Hoek.applyToDefaultsWithShallow(internals.defaults, handlerOptions, ['agent']);
     settings.mapUri = handlerOptions.mapUri || internals.mapUri(handlerOptions.protocol, handlerOptions.host, handlerOptions.port, handlerOptions.uri);
 
+    // kibi: added
     const modifyPayload = handlerOptions.modifyPayload || false;
-    const modifyResponse = handlerOptions.modifyResponse || false;
 
     if (settings.ttl === 'upstream') {
         settings._upstreamTtl = true;
@@ -146,20 +145,6 @@ internals.handler = function (route, handlerOptions) {
                 options.headers['content-type'] = contentType;
             }
 
-
-            const _sendResponse = function (res, ttl, data) {
-
-                let r;
-                if (data && data.body) {
-                    r = reply(data.body).header('content-type', 'application/json');
-                } else {
-                    r = reply(res);
-                }
-                r.ttl(ttl)
-                .code(res.statusCode)
-                .passThrough(!!settings.passThrough);   // Default to false
-            };
-
             const _onError = function (err, res, ttl) {
 
                 if (settings.onResponse) {
@@ -177,7 +162,7 @@ internals.handler = function (route, handlerOptions) {
 
                     if (err) {
                         if (settings.onResponse) {
-                            return settings.onResponse.call(bind, err, res, request, reply, settings, ttl);
+                            return settings.onResponse.call(bind, err, res, request, reply, settings, ttl, data);
                         }
                         return reply(err);
                     }
@@ -196,21 +181,10 @@ internals.handler = function (route, handlerOptions) {
                         return settings.onResponse.call(bind, null, res, request, reply, settings, ttl, data);
                     }
 
-                    if (modifyResponse) {
-                        modifyResponse(res, data).then((ret) => {
-
-                            _sendResponse(ret.response, ttl, ret.data);
-                        }).catch((err) => {
-
-                            let msg = 'Failed request';
-                            if (err.message) {
-                                msg = err.message;
-                            }
-                            return _onError(Boom.badRequest(msg, err));
-                        });
-                    } else {
-                        _sendResponse(res, ttl);
-                    }
+                    return reply(res)
+                    .ttl(ttl)
+                    .code(res.statusCode)
+                    .passThrough(!!settings.passThrough);   // Default to false
                 });
             };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -193,7 +193,7 @@ internals.handler = function (route, handlerOptions) {
                     }
 
                     if (settings.onResponse) {
-                        return settings.onResponse.call(bind, null, res, request, reply, settings, ttl);
+                        return settings.onResponse.call(bind, null, res, request, reply, settings, ttl, data);
                     }
 
                     if (modifyResponse) {

--- a/test/index.js
+++ b/test/index.js
@@ -97,23 +97,20 @@ describe('H2o2', () => {
                         },
                         onResponse: (error, response, request, reply, settings, ttl, data) => {
 
-                            return new Promise((fulfill, reject) => {
+                            if (error) {
+                                reply(error);
+                            }
 
-                                if (error) {
-                                    reject(error);
+                            Wreck.read(response, null, (err, payload) => {
+
+                                if (err) {
+                                    reply(err);
                                 }
 
-                                Wreck.read(response, null, (err, payload) => {
-
-                                    if (err) {
-                                        reject(err);
-                                    }
-
-                                    const body = JSON.parse(payload.toString());
-                                    body.copy = body.copy.toUpperCase();
-                                    body.john = data;
-                                    fulfill(reply(new Buffer(JSON.stringify(body))));
-                                });
+                                const body = JSON.parse(payload.toString());
+                                body.copy = body.copy.toUpperCase();
+                                body.john = data;
+                                reply(new Buffer(JSON.stringify(body)));
                             });
                         }
                     }

--- a/test/index.js
+++ b/test/index.js
@@ -207,7 +207,7 @@ describe('H2o2', () => {
                     kibi_proxy: {
                         host: 'localhost',
                         port: upstream.info.port,
-                        modifyPayload: function (request) {
+                        modifyPayload: (request) => {
 
                             const req = request.raw.req;
                             return new Promise((fulfill, reject) => {
@@ -227,7 +227,7 @@ describe('H2o2', () => {
                                 });
                             });
                         },
-                        onResponse: function (error, response, request, reply, settings, ttl, data) {
+                        onResponse: (error, response, request, reply, settings, ttl, data) => {
 
                             if (error) {
                                 return reply(err);

--- a/test/index.js
+++ b/test/index.js
@@ -78,7 +78,7 @@ describe('H2o2', () => {
                     kibi_proxy: {
                         host: 'localhost',
                         port: upstream.info.port,
-                        modifyPayload: (request) => {
+                        onBeforeSendRequest: (request) => {
 
                             const req = request.raw.req;
                             return new Promise((fulfill, reject) => {
@@ -133,7 +133,7 @@ describe('H2o2', () => {
         });
     });
 
-    it('modifyPayload the request with error', { parallel: false }, (done) => {
+    it('onBeforeSendRequest the request with error', { parallel: false }, (done) => {
 
         const dataHandler = function (request, reply) {
 
@@ -153,7 +153,7 @@ describe('H2o2', () => {
                     kibi_proxy: {
                         host: 'localhost',
                         port: upstream.info.port,
-                        modifyPayload: (request) => {
+                        onBeforeSendRequest: (request) => {
 
                             const req = request.raw.req;
                             return new Promise((fulfill, reject) => {
@@ -207,7 +207,7 @@ describe('H2o2', () => {
                     kibi_proxy: {
                         host: 'localhost',
                         port: upstream.info.port,
-                        modifyPayload: (request) => {
+                        onBeforeSendRequest: (request) => {
 
                             const req = request.raw.req;
                             return new Promise((fulfill, reject) => {


### PR DESCRIPTION
The related issue: https://github.com/sirensolutions/kibi-internal/issues/2145

There is still an error:
```
Unhandled rejection (<{"message":"some error"}>, no stack trace)
Failed tests:
    4) H2o2 onResponse the request with error:
    Timed out (2000ms) - H2o2 onResponse the request with error
```

The problem is that rejection is not handled [here](https://github.com/sirensolutions/h2o2/blob/issue-2145/lib/index.js#L196), thus [this test](https://github.com/sirensolutions/h2o2/blob/issue-2145/test/index.js#L190) doesn't pass. 
I tried to catch it [here](https://github.com/sirensolutions/h2o2/blob/issue-2145/lib/index.js#L196) like this:
```
...
const r = Promise.resolve();
return r.then(() => {
  return settings.onResponse.call(bind, null, res, request, reply, settings, ttl, data);
}).catch((err) => {
  let msg = 'Failed request';
  if (err.message) {
    msg = err.message;
  }
  return _onError(Boom.badRequest(msg, err));
});
...
```
Neveretheless, I got the same unhandled rejection error:
```
  ...Unhandled rejection Error: some error
    at r.then.catch (/home/trex/Development/kibi/h2o2/lib/index.js:204:127)
    at bound (domain.js:280:14)
    at runBound (domain.js:293:12)
    at tryCatcher (/home/trex/Development/kibi/h2o2/node_modules/bluebird/js/release/util.js:11:23)
    at Promise._settlePromiseFromHandler (/home/trex/Development/kibi/h2o2/node_modules/bluebird/js/release/promise.js:489:31)
    at Promise._settlePromise (/home/trex/Development/kibi/h2o2/node_modules/bluebird/js/release/promise.js:546:18)
    at Promise._settlePromise0 (/home/trex/Development/kibi/h2o2/node_modules/bluebird/js/release/promise.js:591:10)
    at Promise._settlePromises (/home/trex/Development/kibi/h2o2/node_modules/bluebird/js/release/promise.js:670:18)
    at Async._drainQueue (/home/trex/Development/kibi/h2o2/node_modules/bluebird/js/release/async.js:125:16)
    at Async._drainQueues (/home/trex/Development/kibi/h2o2/node_modules/bluebird/js/release/async.js:135:10)
    at Immediate.Async.drainQueues (/home/trex/Development/kibi/h2o2/node_modules/bluebird/js/release/async.js:16:14)
    at runCallback (timers.js:637:20)
    at tryOnImmediate (timers.js:610:5)
    at processImmediate [as _immediateCallback] (timers.js:582:5)

x..............................................
  ..............

Failed tests:

  4) H2o2 onResponse the request with error:

      Timed out (2000ms) - H2o2 onResponse the request with error
``` 

I don't know why I get this.