### PR TITLE
Encoding url in proxy

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -154,6 +154,15 @@ internals.handler = function (route, handlerOptions) {
                 return reply(err);
             };
 
+            // Encoding request path
+            const _encodeURL = (path) => {
+                if (decodeURI(path) === path){
+                    path = encodeURI(path);
+                }       
+                return path;
+            };
+            uri = _encodeURL(uri);
+
             const _sendRequest = function () {
 
                 Wreck.request(request.method, uri, options, (err, res) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -155,11 +155,11 @@ internals.handler = function (route, handlerOptions) {
             };
 
             // Encoding request path
-            const _encodeURL = (path) => {
-                if (decodeURI(path) === path){
-                    path = encodeURI(path);
+            const _encodeURL = (url) => {
+                if (decodeURI(url) === url) {
+                    url = encodeURI(url);
                 }       
-                return path;
+                return url;
             };
             uri = _encodeURL(uri);
 


### PR DESCRIPTION
### Description
Internal error when neo4j relationship types in Arabic.

The proxy was not encoding the URLs after decoding it to match the path.

### Screenshot
#### Before
![before](https://user-images.githubusercontent.com/34007216/74962614-2d9da880-5408-11ea-967a-9bc5a207241e.gif)

#### After
![after](https://user-images.githubusercontent.com/34007216/74962624-31c9c600-5408-11ea-8c1a-a5b24688f0ad.gif)

### How to test
#### Steps
Follow the steps in the JIRA ticket.

### Issue reference
[INVE-274]

### Manual tests
- [ ] Done

### Integration test
- [ ] Not needed
- [ ] Done

### Unit tests
- [ ] Done

[INVE-274]: https://sirensolutions.atlassian.net/browse/INVE-274