### PR TITLE
[INVE-28856] Remove default timeout

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,6 @@ internals.defaults = {
     xforward: false,
     passThrough: false,
     redirects: false,
-    timeout: 1000 * 60 * 3, // Timeout request after 3 minutes
     localStatePassThrough: false,   // Pass cookies defined by the server upstream
     maxSockets: Infinity,
     downstreamResponseTime: false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sirensolutions/h2o2",
   "description": "Fork of proxy handler plugin for hapi.js that adds ability to modify request",
-  "version": "9.0.2-kibi-2",
+  "version": "9.0.2-kibi-3",
   "repository": "git://github.com/sirensolutions/h2o2",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
https://sirensolutions.atlassian.net/browse/INVE-28856

When investigate is configured with a base path proxy, the underlying proxy plugin (this project) sets a 3 minute timeout for requests. This PR removes that timeout.

**Steps to test**
1. Set up Investigate to use the [BasePathProxy](https://github.com/sirensolutions/kibi-internal/blob/master/src/cli/cluster/base_path_proxy.js#L21). You can do this simply by ensuring this parameter is commented out in investigate.yml - `# server.basePath: ""`. Investigate will assign a base path if it doesn't exist.

2. Update the dependency in `package.json` to use this branch:

`"@sirensolutions/h2o2": "git+https://github.com/sirensolutions/h2o2#remove-proxy-timeout"`

3. Throttle any HapiJS route by adding a timeout so requests take longer than 3 minutes to handle. I'm using the `/api/ai/chat` route in the Siren AI plugin but you can throttle any other route you want

Add this before the route handler
```javascript
await new Promise((resolve) => setTimeout(resolve, 3.5 * 60 * 1000)); // 3.5 minutes
```

**Expected:** Your request should not timeout after 3 minutes. It should resolve at ~3.5 minutes.